### PR TITLE
Fix ./core export in package.json

### DIFF
--- a/packages/iso-did/package.json
+++ b/packages/iso-did/package.json
@@ -27,8 +27,8 @@
       "import": "./src/key.js"
     },
     "./core": {
-      "types": "./dist/src/key.d.ts",
-      "import": "./src/key.js"
+      "types": "./dist/src/core.d.ts",
+      "import": "./src/core.js"
     }
   },
   "typesVersions": {


### PR DESCRIPTION
# Description

The incorrect file path was used for the `./core` export.

## Type of change

[x] Bug fix (non-breaking change that fixes an issue)
