### PR TITLE
feat: allow revealing ws connection error

### DIFF
--- a/packages/iso-websocket/src/types.ts
+++ b/packages/iso-websocket/src/types.ts
@@ -69,4 +69,12 @@ export interface WSOptions {
    * @param event - The close or connection timeout event
    */
   shouldRetry?: ShouldRetryFn
+  /**
+   * Reveal connection-time error information in Websocket error
+   *
+   * The *browser* spec for Websockets disallows revealing connection error info to prevent attacks but this is not applicable to *server* usage of WS in a trusted environment.
+   *
+   * @default false
+   * */
+  errorInfo?: boolean
 }


### PR DESCRIPTION
# Description

The *browser* spec for Websockets disallows revealing connection error info to prevent attacks but this is not applicable to *server* usage of WS in a trusted environment. When using in node it is not helpful to hide why WS had a connection issue. This PR adds an option to `WSOptions` to allow surfacing the underlying node error, if one is present. The default is `false` to maintain spec compliance and backwards compatibility.

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] This change requires a documentation update
- [x] Comments have been added/updated
