### PR TITLE
feat: export ws events

### DIFF
--- a/packages/iso-websocket/package.json
+++ b/packages/iso-websocket/package.json
@@ -17,6 +17,7 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
+      "events": "./dist/src/events.js",
       "default": "./src/index.js"
     }
   },


### PR DESCRIPTION
# Description

Exports event types from `events.js` so that they can properly used in Typescript code. Without this export in package.json typescript complains there is no module when trying to do 

```js
import { CloseEvent, ErrorEvent, RetryEvent } from "iso-websocket/dist/src/events.js";
```

## Type of change

- [x] New feature (non-breaking change that adds functionality)
