### PR TITLE
feat(iso-passkeys): export parseAttestationObject and unwrapEC2Signature

### DIFF
--- a/packages/iso-passkeys/src/index.js
+++ b/packages/iso-passkeys/src/index.js
@@ -7,7 +7,9 @@ import {
 } from './parsing.js'
 import { supports } from './utils.js'
 
+export { parseAttestationObject } from './parsing.js'
 export { supports } from './utils.js'
+export { unwrapEC2Signature } from './validation.js'
 
 const credentials =
   /** @type {import('./types.js').PublicKeyCredentialsContainer} */ (


### PR DESCRIPTION
# Description

Both functions already exist and are exported from their own modules, but neither is reachable from the package entry point. Relying parties that verify assertions themselves need both:

- parseAttestationObject, to read the COSE public key out of the attestation object at registration time. getPublicKey() covers the common case, but it is registration-only and absent on older authenticators.
- unwrapEC2Signature, to convert the ASN.1 DER signature a P-256 authenticator returns into the raw r||s WebCrypto's ECDSA verify requires. Without it subtle.verify rejects every valid P-256 assertion.

## Type of change

Purely additive: no behaviour changes, nothing renamed or removed, and no new dependency. Export order follows biome's organizeImports.

- [x] New feature (non-breaking change that adds functionality)
